### PR TITLE
Include URL for raw files

### DIFF
--- a/content.css
+++ b/content.css
@@ -4,6 +4,7 @@
 .inline-review-comment,
 .gist table.lines,
 table.diff-table,
-.markdown-body pre {
+.markdown-body pre,
+body > pre {
 	tab-size: 4 !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,14 +10,16 @@
 	},
 	"permissions": [
 		"https://github.com/*/*",
-		"https://gist.github.com/*/*"
+		"https://gist.github.com/*/*",
+		"https://raw.githubusercontent.com/*/*"
 	],
 	"content_scripts": [
 		{
 			"run_at": "document_end",
 			"matches": [
 				"https://github.com/*/*",
-				"https://gist.github.com/*/*"
+				"https://gist.github.com/*/*",
+				"https://raw.githubusercontent.com/*/*"
 			],
 			"css": [
 				"content.css"


### PR DESCRIPTION
This PR adds `https://raw.githubusercontent.com/*/*` so this plugin will be executed on pages such as: https://raw.githubusercontent.com/sindresorhus/tab-size-on-github/master/content.css

Closes #15 